### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "0.12"
 before_script:
   - npm install grunt-cli -g

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -104,10 +104,10 @@ export class HawkularDatasource {
   metricFindQuery(query) {
     var params = "";
     if (query !== undefined) {
-      if (query.startsWith("tags/")) {
+      if (query.substr(0, 5) === "tags/") {
         return this.findTags(query.substr(5).trim());
       }
-      if (query.startsWith("?")) {
+      if (query.charAt(0) === '?') {
         params = query;
       } else {
         params = "?" + query;

--- a/src/variables.js
+++ b/src/variables.js
@@ -27,7 +27,7 @@ export class Variables {
   getVarValues(name, variables) {
     let values = this.templateSrv.replace(name, variables);
     // result might be in like "{id1,id2,id3}" (as string)
-    if (values.startsWith('{')) {
+    if (values.charAt(0) === '{') {
         return values.substring(1, values.length-1).split(',');
     }
     return [values];


### PR DESCRIPTION
- Node version was too old. Grafana requires 0.12, so use 0.12
- Remove usage of string.startsWith (ES2015 - apparently not supported)

Note, I'm not 100% sure why "startsWith" doesn't work in travis build. I was assuming that using babel made us compliant with ES2015, but it seems there's still some interferences.... 