### PR TITLE
Update release process

### DIFF
--- a/RELEASE.adoc
+++ b/RELEASE.adoc
@@ -17,5 +17,12 @@ git push upstream --tags
 
 Some stuff to keep in mind:
 
-- Never commit anything on release. Only allowed commits are master's merge and grunt bump.
+- Never commit any code to release. Only allowed commits are master's merge, grunt bump and plugin.json update.
 - Never pull or rebase release back to master. The commit tagged "ReleaseT0" should never appear on master.
+
+= Releasing to the Grafana plugins repository
+
+- In this repo, release branch, edit plugin.json to update the version
+- Commit, push to release
+- On https://github.com/grafana/grafana-plugin-repository, add new version & SHA1 to repo.json
+- Submit PR


### PR DESCRIPTION
... to release on grafana repo

Note: would be nice to find a way for "grunt bump" to also update plugin.json