### PR TITLE
Issue #36 use /metrics endpoint to check connectivity

### DIFF
--- a/src/datasource.js
+++ b/src/datasource.js
@@ -60,9 +60,7 @@ export class HawkularDatasource {
       method: 'GET',
       headers: this.createHeaders()
     }).then(response => {
-      if (response.status === 200) {
-        return { status: "success", message: "Data source is working, some metrics were found", title: "Success" };
-      } else if (response.status === 204) {
+      if (response.status === 200 || response.status === 204) {
         return { status: "success", message: "Data source is working", title: "Success" };
       } else {
         return { status: "error", message: "Connection failed (" + response.status + ")", title: "Error" };

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -56,17 +56,14 @@ export class HawkularDatasource {
 
   testDatasource() {
     return this.backendSrv.datasourceRequest({
-      url: this.url + '/tenants',
+      url: this.url + '/metrics',
       method: 'GET',
       headers: this.createHeaders()
     }).then(response => {
       if (response.status === 200) {
-        let tenantFound = response.data.filter && response.data.filter(t => t.id === this.tenant).length > 0;
-        if (tenantFound) {
-          return { status: "success", message: "Data source is working", title: "Success" };
-        } else {
-          return { status: "success", message: "Data source is working but the tenant could not be found", title: "Warning" };
-        }
+        return { status: "success", message: "Data source is working, some metrics were found", title: "Success" };
+      } else if (response.status === 204) {
+        return { status: "success", message: "Data source is working", title: "Success" };
       } else {
         return { status: "error", message: "Connection failed (" + response.status + ")", title: "Error" };
       }


### PR DESCRIPTION
Because "/tenants" might be reserved for admins and and "/" may not check authentication in certain cases like under openshift