### PR TITLE
Update the Dockerfile to build from release versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 npm-debug.log
 
 dist/
+docker/hawkular-grafana-datasource-release/
 
 .idea/
 *.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,0 @@
-FROM grafana/grafana:latest
-
-ENV GRAFANA_PLUGINS=/var/lib/grafana/plugins
-ADD dist ${GRAFANA_PLUGINS}/hawkular

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM grafana/grafana:3.1.1
+
+ADD hawkular-grafana-datasource-release/dist /var/lib/grafana/plugins/hawkular-datasource

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# NOTE: ideally these build steps should be integrated directly in the Dockerfile.
+# However, because the grafana base image declares the plugins path as a volume,
+# we cannot pre-install plugins using exclusively the Dockerfile.
+# (see https://github.com/docker/docker/issues/3639)
+# So we must run this script to build the docker image.
+
+rm -r hawkular-grafana-datasource-release
+wget https://github.com/hawkular/hawkular-grafana-datasource/archive/release.zip -O hawkular-grafana-datasource-release.zip && \
+    unzip hawkular-grafana-datasource-release.zip && \
+    rm hawkular-grafana-datasource-release.zip && \
+    docker build -t hawkular/hawkular-grafana-datasource . && \
+    rm -r hawkular-grafana-datasource-release


### PR DESCRIPTION
Note that because the plugins path is declared as a volume in the grafana base image, we cannot straightly download or use grafana-cli from inside the Dockerfile ; we have to work around with that docker/build.sh