### PR TITLE
Fix Grafana 4 showing an error on empty result for live stat

### DIFF
--- a/src/queryProcessor.js
+++ b/src/queryProcessor.js
@@ -208,12 +208,12 @@ export class QueryProcessor {
     if (latestPoints.length === 0) {
       datapoints = [];
     } else {
-      datapoints = [reduceFunc(latestPoints.map(dp => dp.value)), latestPoints[0].timestamp];
+      datapoints = [[reduceFunc(latestPoints.map(dp => dp.value)), latestPoints[0].timestamp]];
     }
     return [{
       refId: target.refId,
       target: "Aggregate",
-      datapoints: [datapoints]
+      datapoints: datapoints
     }];
   }
 }


### PR DESCRIPTION
(tested with Grafana 4 beta 2)
=> on empty result, return an empty array (rather than a singleton array containing itself an empty array, as before)

Note that this fix is compliant with Grafana 3.x