### PR TITLE
Issue #45 with basic auth in direct mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Select the tenant. On Hawkular servers, use `hawkular`.
 
 Openshift-Metrics users must provide an authentication token.
 
+Note that if you configure both Basic Authentication and a Token, only Basic Authentication will be effective.
+
 ## Usage
 
 ### Queries

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -17,8 +17,6 @@ export class HawkularDatasource {
     };
     if (typeof instanceSettings.basicAuth === 'string' && instanceSettings.basicAuth.length > 0) {
       this.headers['Authorization'] = instanceSettings.basicAuth;
-    } else if (typeof instanceSettings.jsonData.username === 'string' && instanceSettings.jsonData.username.length > 0) {
-      this.headers['Authorization'] = 'Basic ' + window.btoa(instanceSettings.jsonData.username + ':' + instanceSettings.jsonData.password);
     } else if (typeof instanceSettings.jsonData.token === 'string' && instanceSettings.jsonData.token.length > 0) {
       this.headers['Authorization'] = 'Bearer ' + instanceSettings.jsonData.token;
     }

--- a/src/queryProcessor.js
+++ b/src/queryProcessor.js
@@ -1,12 +1,12 @@
 export class QueryProcessor {
 
-  constructor(q, backendSrv, variables, capabilities, url, baseHeaders, typeResources) {
+  constructor(q, backendSrv, variables, capabilities, url, headers, typeResources) {
     this.q = q;
     this.backendSrv = backendSrv;
     this.variables = variables;
     this.capabilities = capabilities;
     this.url = url;
-    this.baseHeaders = baseHeaders;
+    this.headers = headers;
     this.typeResources = typeResources;
     this.numericMapping = point => [point.value, point.timestamp];
     this.availMapping = point => [point.value == 'up' ? 1 : 0, point.timestamp];
@@ -80,7 +80,7 @@ export class QueryProcessor {
       url: url,
       data: postData,
       method: 'POST',
-      headers: this.baseHeaders
+      headers: this.headers
     }).then(response => this.processRawResponse(target, response.status == 200 ? response.data : []));
   }
 
@@ -99,7 +99,7 @@ export class QueryProcessor {
           end: range.to.valueOf()
         },
         method: 'GET',
-        headers: this.baseHeaders
+        headers: this.headers
       }).then(response => this.processRawResponseLegacy(target, metric, response.status == 200 ? response.data : []));
     }));
   }
@@ -164,7 +164,7 @@ export class QueryProcessor {
       url: url,
       data: postData,
       method: 'POST',
-      headers: this.baseHeaders
+      headers: this.headers
     }).then(response => this.processSingleStatResponse(target, fnBucket, response.status == 200 ? response.data : []));
   }
 
@@ -191,7 +191,7 @@ export class QueryProcessor {
       url: url,
       data: postData,
       method: 'POST',
-      headers: this.baseHeaders
+      headers: this.headers
     }).then(response => this.processSingleStatLiveResponse(target, response.status == 200 ? response.data : []));
   }
 


### PR DESCRIPTION
In proxy mode, basic auth headers are automatically added while querying hawkular. However in direct access mode, they must be added manually.

Also move headers creation to ctor as they are never modified in datasource object's lifetime, it will save some computation time on queries.