### PR TITLE
Enable import of dashboads from $GF_DASHBOARDS_PATH

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -3,10 +3,14 @@
 : "${GF_PATHS_DATA:=/var/lib/grafana}"
 : "${GF_PATHS_LOGS:=/var/log/grafana}"
 : "${GF_PATHS_PLUGINS:=/var/lib/grafana/plugins}"
+: "${GF_DASHBOARDS_ENABLED:=true}"
+: "${GF_DASHBOARDS_PATH:=/var/lib/grafana/dashboards}"
 
-exec /usr/sbin/grafana-server               \
-  --homepath=/usr/share/grafana             \
-  --config=/etc/grafana/grafana.ini         \
-  cfg:default.paths.data="$GF_PATHS_DATA"   \
-  cfg:default.paths.logs="$GF_PATHS_LOGS"   \
+exec /usr/sbin/grafana-server                               \
+  --homepath=/usr/share/grafana                             \
+  --config=/etc/grafana/grafana.ini                         \
+  cfg:default.paths.data="$GF_PATHS_DATA"                   \
+  cfg:default.paths.logs="$GF_PATHS_LOGS"                   \
+  cfg:default.dashboards.json.enabled=GF_DASHBOARDS_ENABLED \
+  cfg:default.dashboards.json.path="$GF_DASHBOARDS_PATH"    \
   cfg:default.paths.plugins="$GF_PATHS_PLUGINS"


### PR DESCRIPTION
Uses the dashboards.json section, enables it and set the path of json dashboards to automatically be imported on startup