### PR TITLE
Issue #58 customize legend

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,17 @@ Example, JSON posted on [the Hawkular's REST API](http://www.hawkular.org/hawkul
 
 In the case of Hawkular Alerts events, you need to provide the trigger ID (several comma-separated IDs are allowed).
 
+### Legend
+
+Metric names can be customized in chart legend. The `Legend` field can receive regular expressions in that purpose. Regex must be written between double curly braces, and include a parentheses group to design what must be written: `{{(.*)}}`
+
+_Example:_
+>  From metric name `pod/c6e2a9ab-8d1c-11e7-b7be-06415eb17bbf/custom/haproxy_server_bytes_in_total{namespace=my-namespace,pod=web-45-6f464,route=web,server=10.1.10.138:8080,service=web}`
+>
+>  Legend: `HAProxy Server Bytes {{namespace=([^,}]+)}} / {{pod=([^,}]+)}}`
+>
+>  Result: `HAProxy Server Bytes my-namespace / web-45-6f464`
+
 ## Installing from sources
 
 Additional information on installing from sources can be found on [hawkular.org](http://www.hawkular.org/hawkular-clients/grafana/docs/quickstart-guide/).

--- a/spec/datasource_spec.js
+++ b/spec/datasource_spec.js
@@ -316,4 +316,23 @@ describe('HawkularDatasource', () => {
       expect(result[1]).to.deep.equal({ text: 'app', value: 'app' });
     }).then(v => done(), err => done(err));
   });
+
+  it('should get name without legend', done => {
+    let legend = ctx.ds.queryProcessor.legend({}, "my-metric");
+    expect(legend).to.equal('my-metric');
+    done();
+  });
+
+  it('should get simple legend', done => {
+    let legend = ctx.ds.queryProcessor.legend({legend: "my-legend"}, "my-metric");
+    expect(legend).to.equal('my-legend');
+    done();
+  });
+
+  it('should resolve regex in legend', done => {
+    let legend = ctx.ds.queryProcessor.legend({legend: "my-legend {{a}} {{foo=([^,}]+)}} {{foo2=([^,}]+)}}"},
+      "my-metric{foo=bar,foo2=bar2}");
+    expect(legend).to.equal('my-legend {{a}} bar bar2');
+    done();
+  });
 });

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -78,4 +78,13 @@
 			</div>
 		</div>
 	</div>
+	<!-- chart panel -->
+	<div ng-if="ctrl.panel.type !== 'singlestat'">
+		<div class="gf-form-inline">
+			<div class="gf-form">
+				<label class="gf-form-label query-keyword fix-query-keyword">Legend</label>
+				<input type="text" class="gf-form-input" ng-model="ctrl.target.legend" ng-change="ctrl.onChangeInternal()" placeholder="default">
+			</div>
+		</div>
+	</div>
 </query-editor-row>


### PR DESCRIPTION
Customize legend using user-defined regex applied on metric name
Ex: from base name "pod/c6e2a9ab-8d1c-11e7-b7be-06415eb17bbf/custom/haproxy_server_bytes_in_total{namespace=my-namespace,pod=web-45-6f464,route=web,server=10.1.10.138:8080,service=web}"

Legend: "HAProxy Server Bytes {{namespace=([^,}]+)}} / {{pod=([^,}]+)}}"

Would result in: "HAProxy Server Bytes my-namespace / web-45-6f464"